### PR TITLE
Fix log file name inconsistency in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can deploy a local optimism devnet equipped with Kailua through the followin
     * Builds the local cargo and foundry projects.
 3. `just devnet-up`
     * Starts a local OP Stack devnet using docker.
-    * Dumps the output into `devnetlog.txt` for inspection.
+    * Dumps the output into `devnet.log` for inspection.
 4. `just devnet-upgrade`
     * Upgrades the devnet to use the `KailuaGame` contract.
     * Assumes the default values of the local optimism devnet, but can take parameters.

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -33,7 +33,7 @@ You can deploy a local optimism devnet equipped with Kailua through the followin
     * Builds the local cargo and foundry projects.
 3. `just devnet-up`
     * Starts a local OP Stack devnet using docker.
-    * Dumps the output into `devnetlog.txt` for inspection.
+    * Dumps the output into `devnet.log` for inspection.
 4. `just devnet-upgrade`
     * Upgrades the devnet to use the `KailuaGame` contract.
     * Assumes the default values of the local optimism devnet, but can take parameters.


### PR DESCRIPTION
Update documentation to reference the correct log file name `devnet.log` instead of `devnetlog.txt`. The justfile creates `devnet.log` but documentation referenced the incorrect filename, which would confuse users trying to find the devnet logs for debugging