### PR TITLE
feat: Limit number of stitched derivation proofs per request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6289,6 +6289,7 @@ dependencies = [
  "hokulea-proof",
  "hokulea-witgen",
  "human_bytes",
+ "itertools 0.14.0",
  "kailua-build",
  "kailua-hana",
  "kailua-hokulea",

--- a/bin/cli/tests/devnet.rs
+++ b/bin/cli/tests/devnet.rs
@@ -283,6 +283,7 @@ async fn proposer_validator() {
                 segment_limit: 21,
                 max_block_derivations: usize::MAX,
                 max_block_executions: usize::MAX,
+                max_proof_stitches: usize::MAX,
                 max_witness_size: 2_684_354_560,
                 num_tail_blocks: 10,
                 num_concurrent_preflights: 1,
@@ -343,6 +344,7 @@ async fn proposer_validator() {
                 segment_limit: 21,
                 max_block_derivations: usize::MAX,
                 max_block_executions: usize::MAX,
+                max_proof_stitches: usize::MAX,
                 max_witness_size: 2_684_354_560,
                 num_tail_blocks: 10,
                 num_concurrent_preflights: 1,
@@ -490,6 +492,7 @@ async fn prover() {
             segment_limit: 21,
             max_block_derivations: usize::MAX,
             max_block_executions: usize::MAX,
+            max_proof_stitches: usize::MAX,
             max_witness_size: 5 * 1024 * 1024, // 5 MB witness maximum
             num_tail_blocks: 10,
             num_concurrent_preflights: 4,

--- a/book/src/validator.md
+++ b/book/src/validator.md
@@ -65,6 +65,7 @@ The validator proving behavior can be customized through the following arguments
 * `num-concurrent-r0vm`: How many threads to use for zkvm executors per prover.
 * `segment-limit`: ZKVM Proving Segment Limit (Default 21).
 * `max-witness-size`: Maximum input data byte size per single proof (Default 2.5 GB).
+* `max-proof-stitches`: Maximum number of derivation proofs to aggregate per stitching proof.
 * `max-block-derivations`: Maximum number of blocks to derive per single proof.
 * `max-block-executions`: Maximum number of blocks to execute per single proof.
 * `num-tail-blocks`: Rate of growth of tail proofs in L1 blocks (Default 10).

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -23,6 +23,7 @@ clap.workspace = true
 futures.workspace = true
 hex.workspace = true
 human_bytes.workspace = true
+itertools.workspace = true
 lazy_static.workspace = true
 rkyv.workspace = true
 serde.workspace = true

--- a/crates/prover/src/args.rs
+++ b/crates/prover/src/args.rs
@@ -122,7 +122,7 @@ impl ProvingArgs {
     }
 
     pub fn skip_stitching(&self) -> bool {
-        self.skip_derivation_proof || self.skip_await_proof || self.max_proof_stitches == 0
+        self.skip_derivation_proof || self.skip_await_proof || self.max_proof_stitches <= 1
     }
 
     pub fn use_hokulea(&self) -> bool {

--- a/crates/prover/src/args.rs
+++ b/crates/prover/src/args.rs
@@ -40,6 +40,9 @@ pub struct ProvingArgs {
     /// Maximum number of blocks to execute per proof
     #[clap(long, env, required = false, default_value_t = usize::MAX)]
     pub max_block_executions: usize,
+    /// Maximum number of proofs to stitch per proof
+    #[clap(long, env, required = false, default_value_t = usize::MAX)]
+    pub max_proof_stitches: usize,
     /// Maximum input data size per proof
     #[clap(long, env, required = false, default_value_t = 2_684_354_560)]
     pub max_witness_size: usize,
@@ -119,7 +122,7 @@ impl ProvingArgs {
     }
 
     pub fn skip_stitching(&self) -> bool {
-        self.skip_derivation_proof || self.skip_await_proof
+        self.skip_derivation_proof || self.skip_await_proof || self.max_proof_stitches == 0
     }
 
     pub fn use_hokulea(&self) -> bool {

--- a/crates/prover/src/client/native.rs
+++ b/crates/prover/src/client/native.rs
@@ -52,6 +52,7 @@ use tracing::info;
 pub async fn run_native_client(
     args: ProveArgs,
     disk_kv_store: Option<RWLKeyValueStore>,
+    precondition: Precondition,
     proposal_data_hash: B256,
     stitched_executions: Vec<Vec<Execution>>,
     derivation_cache: Option<CachedDriver>,
@@ -147,6 +148,7 @@ pub async fn run_native_client(
         args.boundless,
         OracleReader::new(preimage.client),
         HintWriter::new(hint.client),
+        precondition,
         proposal_data_hash,
         stitched_executions,
         derivation_cache,

--- a/crates/prover/src/client/proving.rs
+++ b/crates/prover/src/client/proving.rs
@@ -61,6 +61,7 @@ pub async fn run_proving_client<P, H>(
     boundless: BoundlessArgs,
     oracle_client: P,
     hint_client: H,
+    precondition: Precondition,
     proposal_data_hash: B256,
     stitched_executions: Vec<Vec<Execution>>,
     derivation_cache: Option<CachedDriver>,
@@ -99,7 +100,7 @@ where
     let (
         _boot_info,
         proof_journal,
-        precondition,
+        updated_precondition,
         traced_driver,
         witness,
         extra_frames,
@@ -242,10 +243,10 @@ where
     let driver_file = driver_file_name(proving.image_id(), &driver_boot, &precondition);
     if let Some(traced_driver) = traced_driver.as_ref() {
         let driver_digest = B256::new(traced_driver.digest().into());
-        if driver_digest != precondition.derivation_trace {
+        if driver_digest != updated_precondition.derivation_trace {
             error!(
                 "Witgen derivation trace hash mismatch: Output {driver_digest}, precondition: {}",
-                precondition.derivation_trace
+                updated_precondition.derivation_trace
             );
         }
         match rkyv::to_bytes::<Error>(traced_driver) {
@@ -268,10 +269,10 @@ where
     }
 
     // Sanity check
-    let precondition_hash = B256::new(precondition.digest().into());
+    let precondition_hash = B256::new(updated_precondition.digest().into());
     if proof_journal.precondition_hash != precondition_hash {
         error!(
-            "ProofJournal precondition hash mismatch: found {} expected {} for {precondition:?}.",
+            "ProofJournal precondition hash mismatch: found {} expected {} for {updated_precondition:?}.",
             proof_journal.precondition_hash, precondition_hash
         );
     }

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -386,12 +386,6 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<bool> {
                         continue;
                     }
                 };
-                // todo: delete
-                // // Instantiate driver cache relays
-                // if num_proofs == 1 {
-                //     (derivation_trace, derivation_cache_receiver) =
-                //         Some(async_channel::bounded::<CachedDriver>(1)).unzip();
-                // }
                 // Require additional proof
                 num_proofs += 1;
                 // Split workload at midpoint (num_blocks > 1)

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -25,6 +25,7 @@ use alloy::providers::{Provider, RootProvider};
 use alloy_primitives::B256;
 use anyhow::{anyhow, bail, Context};
 use human_bytes::human_bytes;
+use itertools::Itertools;
 use kailua_kona::boot::StitchedBootInfo;
 use kailua_kona::driver::CachedDriver;
 use kailua_kona::journal::ProofJournal;
@@ -472,10 +473,18 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<bool> {
             // compute a stitched proof for each subsequence of proofs
             for stitched_proofs in results.chunks(args.proving.max_proof_stitches) {
                 // construct a list of boot info to backward stitch
-                let (stitched_proofs, stitched_preconditions): (Vec<_>, Vec<_>) = stitched_proofs
+                let (stitched_proofs, stitched_preconditions, initial_preconditions, initial_args): (
+                    Vec<_>,
+                    Vec<_>,
+                    Vec<_>,
+                    Vec<_>,
+                ) = stitched_proofs
                     .iter()
-                    .map(|r| r.result.as_ref().unwrap().clone())
-                    .unzip();
+                    .map(|r| {
+                        let (proof, precondition) = r.result.as_ref().unwrap().clone();
+                        (proof, precondition, r.cached_task.precondition, r.cached_task.args.kona.clone())
+                    })
+                    .multiunzip();
                 let stitched_boot_info = stitched_proofs
                     .iter()
                     .map(StitchedBootInfo::from)
@@ -518,20 +527,22 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<bool> {
                 let driver_cache = match last_stitched_precondition.derivation_trace.is_zero() {
                     true => None,
                     false => {
+                        let last_initial_precondition = initial_preconditions.first().unwrap();
+                        let last_initial_args = initial_args.first().unwrap();
                         let last_stitched_journal =
                             ProofJournal::from(stitched_proofs.first().unwrap());
                         let boot = BootInfo {
-                            l1_head: last_stitched_journal.l1_head,
-                            agreed_l2_output_root: last_stitched_journal.agreed_l2_output_root,
-                            claimed_l2_output_root: last_stitched_journal.claimed_l2_output_root,
-                            claimed_l2_block_number: last_stitched_journal.claimed_l2_block_number,
+                            l1_head: last_initial_args.l1_head,
+                            agreed_l2_output_root: last_initial_args.agreed_l2_output_root,
+                            claimed_l2_output_root: last_initial_args.claimed_l2_output_root,
+                            claimed_l2_block_number: last_initial_args.claimed_l2_block_number,
                             chain_id: rollup_config.l2_chain_id,
                             rollup_config: rollup_config.clone(),
                         };
                         let driver_file = driver_file_name(
                             *last_stitched_journal.fpvm_image_id,
                             &boot,
-                            last_stitched_precondition,
+                            last_initial_precondition,
                         );
                         try_read_driver(&driver_file).await
                     }
@@ -540,6 +551,7 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<bool> {
                     .as_ref()
                     .map(|c| B256::new(c.digest().into()))
                     .unwrap_or_default();
+                info!("Preparing stitching task with driver trace: {driver_cache_hash}");
                 let derivation_cache_receiver = match driver_cache {
                     Some(cache) => {
                         let (sender, receiver) = async_channel::bounded(1);
@@ -557,13 +569,14 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<bool> {
                 let disk_kv_store = disk_kv_store.clone();
                 let task_channel = task_channel.clone();
                 tokio::spawn(async move {
+                    let precondition = Precondition::default()
+                        .proposal(proposal_precondition_hash)
+                        .derivation(driver_cache_hash, driver_cache_hash);
                     let result = crate::tasks::compute_fpvm_proof(
                         stitch_job_args.clone(),
                         rollup_config,
                         disk_kv_store,
-                        Precondition::default()
-                            .proposal(proposal_precondition_hash)
-                            .derivation(driver_cache_hash, driver_cache_hash),
+                        precondition,
                         proposal_data_hash,
                         derivation_cache_receiver,
                         None,
@@ -576,7 +589,7 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<bool> {
                     .await;
 
                     result_sender
-                        .send((stitch_job_args, result))
+                        .send((stitch_job_args, precondition, result))
                         .await
                         .expect("Failed to send fpvm proof result");
                 });
@@ -586,7 +599,7 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<bool> {
             // assign new results
             results = Vec::with_capacity(stitched_proof_receivers.len());
             for receiver in stitched_proof_receivers {
-                let (stitch_job_args, result) = receiver
+                let (stitch_job_args, precondition, result) = receiver
                     .recv()
                     .await
                     .expect("stitched_proof_receiver should not be closed");
@@ -596,7 +609,7 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<bool> {
                         args: stitch_job_args,
                         rollup_config: rollup_config.clone(),
                         disk_kv_store: disk_kv_store.clone(),
-                        precondition: Default::default(),
+                        precondition,
                         proposal_data_hash,
                         stitched_executions: vec![],
                         derivation_cache: None,

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -15,6 +15,7 @@
 use crate::args::ProveArgs;
 use crate::channel::AsyncChannel;
 use crate::config::generate_rollup_config_file;
+use crate::driver::{driver_file_name, try_read_driver};
 use crate::kv::create_disk_kv_store;
 use crate::preflight::{concurrent_execution_preflight, fetch_precondition_data};
 use crate::tasks::{handle_oneshot_tasks, CachedTask, Oneshot, OneshotResult};
@@ -26,12 +27,16 @@ use anyhow::{anyhow, bail, Context};
 use human_bytes::human_bytes;
 use kailua_kona::boot::StitchedBootInfo;
 use kailua_kona::driver::CachedDriver;
+use kailua_kona::journal::ProofJournal;
 use kailua_kona::precondition::Precondition;
 use kailua_sync::provider::optimism::OpNodeProvider;
 use kailua_sync::{await_tel, retry_res_ctx_timeout};
+use kona_host::single::SingleChainHost;
+use kona_proof::BootInfo;
 use opentelemetry::global::tracer;
 use opentelemetry::trace::FutureExt;
 use opentelemetry::trace::{TraceContextExt, Tracer};
+use risc0_zkvm::sha::Digestible;
 use std::collections::BinaryHeap;
 use std::env::set_var;
 use tempfile::tempdir;
@@ -126,7 +131,7 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<bool> {
     let result_channel = async_channel::unbounded();
     // create channel for receiving proof requests to process and dispatch to handlers
     let prover_channel = async_channel::unbounded();
-    // create channel for receiving final derivation trace in case of stitching
+    // create channel for receiving the last derivation trace in case of stitching
     let mut derivation_cache_receiver = None;
     // dispatch requested proof
     let mut num_proofs = 0;
@@ -314,7 +319,7 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<bool> {
                     proposal_data_hash,
                     stitched_executions: vec![],
                     derivation_cache: None,
-                    derivation_trace: None,
+                    derivation_trace_sender: None,
                     stitched_preconditions: vec![],
                     stitched_boot_info: vec![],
                     stitched_proofs: vec![],
@@ -341,7 +346,7 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<bool> {
             }
             Err(err) => {
                 // Handle error case
-                let (derivation_cache, mut derivation_trace) = match err {
+                let (derivation_cache, derivation_trace) = match err {
                     ProvingError::WitnessSizeError(preloaded, streamed, limit, _, d, s) => {
                         if force_attempt {
                             bail!(
@@ -380,11 +385,12 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<bool> {
                         continue;
                     }
                 };
-                // Instantiate driver cache relays
-                if num_proofs == 1 {
-                    (derivation_trace, derivation_cache_receiver) =
-                        Some(async_channel::bounded::<CachedDriver>(1)).unzip();
-                }
+                // todo: delete
+                // // Instantiate driver cache relays
+                // if num_proofs == 1 {
+                //     (derivation_trace, derivation_cache_receiver) =
+                //         Some(async_channel::bounded::<CachedDriver>(1)).unzip();
+                // }
                 // Require additional proof
                 num_proofs += 1;
                 // Split workload at midpoint (num_blocks > 1)
@@ -452,62 +458,160 @@ pub async fn prove(mut args: ProveArgs) -> anyhow::Result<bool> {
     // recursively combine expected proofs
     if !args.proving.skip_stitching() && result_pq.len() > 1 {
         // gather sorted proofs into vec
-        let results = result_pq
+        let mut results = result_pq
             .into_sorted_vec()
             .into_iter()
             .rev()
-            .map(|r| r.result.expect("Failed to get result"))
             .collect::<Vec<_>>();
 
-        // stitch contiguous proofs together
-        info!("Composing {} proofs together.", results.len());
-        // construct a proving instruction with no blocks to derive
-        let mut base_args = args.clone();
-        {
-            // set last block as starting point
-            base_args.kona.agreed_l2_output_root = base_args.kona.claimed_l2_output_root;
-            let l2_provider = l2_provider.as_ref().unwrap();
-            base_args.kona.agreed_l2_head_hash = await_tel!(
-                context,
-                tracer,
-                "l2_provider get_block_by_number claimed_l2_block_number",
-                retry_res_ctx_timeout!(
-                    args.timeouts.op_geth_timeout,
-                    l2_provider
-                        .get_block_by_number(BlockNumberOrTag::Number(
-                            base_args.kona.claimed_l2_block_number,
-                        ))
+        let l2_provider = l2_provider.as_ref().unwrap();
+        // collapse results vector by stitching its proofs
+        while results.len() > 1 {
+            let num_stitch_proofs = results.len().div_ceil(args.proving.max_proof_stitches);
+            let mut stitched_proof_receivers = Vec::with_capacity(num_stitch_proofs);
+            // compute a stitched proof for each subsequence of proofs
+            for stitched_proofs in results.chunks(args.proving.max_proof_stitches) {
+                // construct a list of boot info to backward stitch
+                let (stitched_proofs, stitched_preconditions): (Vec<_>, Vec<_>) = stitched_proofs
+                    .iter()
+                    .map(|r| r.result.as_ref().unwrap().clone())
+                    .unzip();
+                let stitched_boot_info = stitched_proofs
+                    .iter()
+                    .map(StitchedBootInfo::from)
+                    .collect::<Vec<_>>();
+                // stitch contiguous proofs together
+                info!("Composing {} proofs together.", stitched_proofs.len());
+                // construct a proving instruction with no blocks to derive
+                let mut stitch_job_args = args.clone();
+                {
+                    let last_stitched_boot = stitched_boot_info.first().unwrap();
+                    // set last block as starting point
+                    let agreed_l2_head_hash = await_tel!(
+                        context,
+                        tracer,
+                        "l2_provider get_block_by_number claimed_l2_block_number",
+                        retry_res_ctx_timeout!(
+                            args.timeouts.op_geth_timeout,
+                            l2_provider
+                                .get_block_by_number(BlockNumberOrTag::Number(
+                                    last_stitched_boot.claimed_l2_block_number,
+                                ))
+                                .await
+                                .context("l2_provider get_block_by_number claimed_l2_block_number")?
+                                .ok_or_else(|| anyhow!("Claimed L2 block not found"))
+                        )
+                    )
+                    .header
+                    .hash;
+                    stitch_job_args.kona = SingleChainHost {
+                        l1_head: last_stitched_boot.l1_head,
+                        agreed_l2_head_hash,
+                        agreed_l2_output_root: last_stitched_boot.claimed_l2_output_root,
+                        claimed_l2_output_root: last_stitched_boot.claimed_l2_output_root,
+                        claimed_l2_block_number: last_stitched_boot.claimed_l2_block_number,
+                        ..stitch_job_args.kona
+                    };
+                }
+                // load the required CachedDriver for stitching
+                let last_stitched_precondition = stitched_preconditions.first().unwrap();
+                let driver_cache = match last_stitched_precondition.derivation_trace.is_zero() {
+                    true => None,
+                    false => {
+                        let last_stitched_journal =
+                            ProofJournal::from(stitched_proofs.first().unwrap());
+                        let boot = BootInfo {
+                            l1_head: last_stitched_journal.l1_head,
+                            agreed_l2_output_root: last_stitched_journal.agreed_l2_output_root,
+                            claimed_l2_output_root: last_stitched_journal.claimed_l2_output_root,
+                            claimed_l2_block_number: last_stitched_journal.claimed_l2_block_number,
+                            chain_id: rollup_config.l2_chain_id,
+                            rollup_config: rollup_config.clone(),
+                        };
+                        let driver_file = driver_file_name(
+                            *last_stitched_journal.fpvm_image_id,
+                            &boot,
+                            last_stitched_precondition,
+                        );
+                        try_read_driver(&driver_file).await
+                    }
+                };
+                let driver_cache_hash = driver_cache
+                    .as_ref()
+                    .map(|c| B256::new(c.digest().into()))
+                    .unwrap_or_default();
+                let derivation_cache_receiver = match driver_cache {
+                    Some(cache) => {
+                        let (sender, receiver) = async_channel::bounded(1);
+                        sender
+                            .send(cache)
+                            .await
+                            .expect("Failed to send driver cache for stitched proof");
+                        Some(receiver)
+                    }
+                    None => None,
+                };
+                // spawn an async task that computes the proof using one of the instantiated handlers and sends back the result to result_receiver
+                let (result_sender, result_receiver) = async_channel::unbounded();
+                let rollup_config = rollup_config.clone();
+                let disk_kv_store = disk_kv_store.clone();
+                let task_channel = task_channel.clone();
+                tokio::spawn(async move {
+                    let result = crate::tasks::compute_fpvm_proof(
+                        stitch_job_args.clone(),
+                        rollup_config,
+                        disk_kv_store,
+                        Precondition::default()
+                            .proposal(proposal_precondition_hash)
+                            .derivation(driver_cache_hash, driver_cache_hash),
+                        proposal_data_hash,
+                        derivation_cache_receiver,
+                        None,
+                        stitched_preconditions,
+                        stitched_boot_info,
+                        stitched_proofs,
+                        false,
+                        task_channel.0.clone(),
+                    )
+                    .await;
+
+                    result_sender
+                        .send((stitch_job_args, result))
                         .await
-                        .context("l2_provider get_block_by_number claimed_l2_block_number")?
-                        .ok_or_else(|| anyhow!("Claimed L2 block not found"))
-                )
-            )
-            .header
-            .hash;
-        }
-        // construct a list of boot info to backward stitch
-        let (proofs, stitched_preconditions): (Vec<_>, Vec<_>) = results.into_iter().unzip();
-        let stitched_boot_info = proofs
-            .iter()
-            .map(StitchedBootInfo::from)
-            .collect::<Vec<_>>();
+                        .expect("Failed to send fpvm proof result");
+                });
 
-        crate::tasks::compute_fpvm_proof(
-            base_args,
-            rollup_config.clone(),
-            disk_kv_store.clone(),
-            Precondition::default().proposal(proposal_precondition_hash),
-            proposal_data_hash,
-            derivation_cache_receiver,
-            None,
-            stitched_preconditions,
-            stitched_boot_info,
-            proofs,
-            true,
-            task_channel.0.clone(),
-        )
-        .await
-        .context("Failed to compute stitched FPVM proof.")?;
+                stitched_proof_receivers.push(result_receiver);
+            }
+            // assign new results
+            results = Vec::with_capacity(stitched_proof_receivers.len());
+            for receiver in stitched_proof_receivers {
+                let (stitch_job_args, result) = receiver
+                    .recv()
+                    .await
+                    .expect("stitched_proof_receiver should not be closed");
+
+                results.push(OneshotResult {
+                    cached_task: CachedTask {
+                        args: stitch_job_args,
+                        rollup_config: rollup_config.clone(),
+                        disk_kv_store: disk_kv_store.clone(),
+                        precondition: Default::default(),
+                        proposal_data_hash,
+                        stitched_executions: vec![],
+                        derivation_cache: None,
+                        derivation_trace_sender: None,
+                        stitched_preconditions: vec![],
+                        stitched_boot_info: vec![],
+                        stitched_proofs: vec![],
+                        prove_snark: false,
+                        force_attempt: false,
+                        seek_proof: true,
+                    },
+                    result: result.map(|inner| inner.expect("Missing stitched proof.")),
+                });
+            }
+        }
     }
 
     // Cleanup cached data


### PR DESCRIPTION
This PR adds a `max-proof-stitches` config that allows final derivation aggregation proofs to be broken down into smaller concurrent tasks instead of proving one large bottleneck stitching proof at the end.